### PR TITLE
Kubernetes monitoring

### DIFF
--- a/kubernetes-monitoring/deployment.yaml
+++ b/kubernetes-monitoring/deployment.yaml
@@ -20,7 +20,7 @@ spec:
 
         - name: nginx-prometheus-exporter
           image: nginx/nginx-prometheus-exporter:latest
-          # args: ["-nginx.scrape-uri", "http://localhost:8000/metrics"]
+          args: ["-nginx.scrape-uri", "http://localhost:8000/metrics"]
           ports:
             - name: web
               containerPort: 9113

--- a/kubernetes-monitoring/deployment.yaml
+++ b/kubernetes-monitoring/deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dz8-nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dz8-nginx
+  template:
+    metadata:
+      labels:
+        app: dz8-nginx
+    spec:
+      containers:
+        - name: nginx
+          image: docker.io/redrrah/nginx:v5
+          ports:
+            - containerPort: 8000
+
+        - name: nginx-prometheus-exporter
+          image: nginx/nginx-prometheus-exporter:latest
+          # args: ["-nginx.scrape-uri", "http://localhost:8000/metrics"]
+          ports:
+            - name: web
+              containerPort: 9113

--- a/kubernetes-monitoring/nginx/Dockerfile
+++ b/kubernetes-monitoring/nginx/Dockerfile
@@ -1,0 +1,9 @@
+FROM nginx:1.25
+COPY default.conf /etc/nginx/conf.d/default.conf
+RUN apt update && \
+    apt install wget
+RUN wget https://github.com/nginxinc/nginx-prometheus-exporter/releases/download/v1.1.0/nginx-prometheus-exporter_1.1.0_linux_amd64.tar.gz && \
+    tar -xvf nginx-prometheus-exporter_1.1.0_linux_amd64.tar.gz && \
+    mv nginx-prometheus-exporter /usr/local/bin/
+EXPOSE 8000
+CMD ["nginx", "-g", "daemon off;"]

--- a/kubernetes-monitoring/nginx/default.conf
+++ b/kubernetes-monitoring/nginx/default.conf
@@ -1,0 +1,14 @@
+server {
+    listen 8000;
+
+    location / {
+        root /usr/share/nginx/html;
+        index index.html index.htm;
+   }
+
+    location /metrics {
+        stub_status on;
+        allow 127.0.0.1;  # Allow access to metrics only locally
+        deny all;          # Deny access to metrics for everyone else
+   }
+}

--- a/kubernetes-monitoring/service-mon.yaml
+++ b/kubernetes-monitoring/service-mon.yaml
@@ -1,0 +1,13 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: nginx-servicemonitor
+  labels:
+    team: homework
+spec:
+  selector:
+    matchLabels:
+      app: dz8-nginx
+  endpoints:
+  - port: web
+    interval: 30s

--- a/kubernetes-monitoring/service.yaml
+++ b/kubernetes-monitoring/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dz8-nginx-service
+spec:
+  selector:
+    app: dz8-nginx
+  ports:
+    - protocol: TCP
+      port: 8000
+      targetPort: 8000
+      name: http
+    - port: 9113
+      targetPort: 9113
+      name: metrics


### PR DESCRIPTION
# Выполнено ДЗ №8

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
- Cоздан кастомный образ nginx, отдающий свои метрики на endpoint /metrics - docker.io/redrrah/nginx:v5
- Установлен в кластер Prometheus-operator 
`helm install kube-prometheus oci://registry-1.docker.io/bitnamicharts/kube-prometheus`
- Создан deployment запускающий кастомный nginx образ и nginx prometheus exporter
- Создан манифест serviceMonitor, описывающий сбор метрик с под

## Как запустить проект:
 - kubectl apply -f ./kubernetes-monitoring

## Как проверить работоспособность:
 - Пробросить порт `kubectl port-forward pod/prometheus-kube-prometheus-prometheus-0 9090:9090`
 - По ссылке http://localhost:9090 откроется веб прометеуса, где можно посмотреть доступные метрики, например: 
 
![Снимок экрана_2024-04-18_22-04-36](https://github.com/Kuber-2023-12OTUS/Redrrah_repo/assets/20030296/704a2875-a683-4489-b256-4dafa8c36075)


## PR checklist:
 - [x] Выставлен label с темой домашнего задания
