### PR TITLE
kubernetes-logging

### DIFF
--- a/kubernetes-logging/grafana/values.yaml
+++ b/kubernetes-logging/grafana/values.yaml
@@ -1,0 +1,8 @@
+nodeSelector:
+  infra: "true"
+tolerations:
+  - key: "node-role"        
+    operator: "Equal"
+    value: "infra"        
+    effect: "NoSchedule"
+image.tag: 8.5.28

--- a/kubernetes-logging/loki/values.yaml
+++ b/kubernetes-logging/loki/values.yaml
@@ -1,0 +1,50 @@
+loki:
+  storage:
+    bucketNames:
+      chunks: otus-red
+      ruler: otus-red
+      admin: otus-red
+    type: 's3'
+    s3:
+      endpoint: storage.yandexcloud.net
+      secretAccessKey: <SECRET_ACCESS_KEY>
+      accessKeyId: <ACCERSS_KEY_ID>
+  auth_enabled: false
+  commonConfig:
+    replication_factor: 1
+
+test:
+  enabled: false
+
+monitoring:
+  selfMonitoring:
+    enabled: false
+    grafanaAgent:
+      installOperator: false
+  lokiCanary:
+    nodeSelector:
+      infra: "true"
+    tolerations:
+      - key: "node-role"        
+        operator: "Equal"
+        value: "infra"        
+        effect: "NoSchedule"
+
+singleBinary:
+  replicas: 1
+  nodeSelector:
+    infra: "true"
+  tolerations:
+    - key: "node-role"        
+      operator: "Equal"
+      value: "infra"        
+      effect: "NoSchedule"
+
+gateway:
+  nodeSelector:
+    infra: "true"
+  tolerations:
+    - key: "node-role"        
+      operator: "Equal"
+      value: "infra"        
+      effect: "NoSchedule"

--- a/kubernetes-logging/promtail/values.yaml
+++ b/kubernetes-logging/promtail/values.yaml
@@ -1,0 +1,10 @@
+config:
+  # publish data to loki
+  clients:
+    - url: http://loki-gateway/loki/api/v1/push
+      tenant_id: 1
+tolerations:
+  - key: "node-role"        
+    operator: "Equal"
+    value: "infra"        
+    effect: "NoSchedule"


### PR DESCRIPTION
# Выполнено ДЗ №9

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
- Средствами yc развернул в Yandex cloud  Managed Kubernetes
- В кластере создал пулы нод, с метками work="true",  infra="true" согласно требованиям методички под рабочую и инфраструктурную нагрузку
- Для инфраструктурных нод добавил taint "node-role=infra:NoSchedule"
- Создан S3 бакет otus-red
- Через helm-чарта установил loki, Promtail, Grafana
- Созданы volumes.yaml для каждого из: oki, Promtail, Grafana

## Как запустить проект:
 - Добавить репозиторий
 `helm repo add grafana https://grafana.github.io/helm-charts`
 -  Для установки loki 
 `helm upgrade --install --values loki/values.yaml loki --namespace=monitoring grafana/loki --version 5.47.0`
 - Для установки Promtail
 `helm upgrade --values promtail/values.yaml --install promtail grafana/promtail -n monitoring`
 - Для установки Grafana
 `$ helm install my-grafana grafana/grafana -f grafana/values.yaml -n monitoring`
 - Пробросить порты для Grafana
 `kubectl --namespace monitoring port-forward $POD_NAME 3000`
 - Указать Datasource для loki http://loki-gateway.monitoring.svc.cluster.local

## Как проверить работоспособность:
 - Вывод команд из методички для проверки ДЗ9
 ```
 $ kubectl get node -o wide --show-labels
NAME      STATUS   ROLES    AGE   VERSION   INTERNAL-IP    EXTERNAL-IP      OS-IMAGE             KERNEL-VERSION      CONTAINER-RUNTIME     LABELS
infra-1   Ready    <none>   21h   v1.26.2   192.168.1.21   158.160.57.34    Ubuntu 20.04.6 LTS   5.4.0-174-generic   containerd://1.6.28   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=standard-v3,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/zone=ru-central1-a,infra=true,kubernetes.io/arch=amd64,kubernetes.io/hostname=infra-1,kubernetes.io/os=linux,node.kubernetes.io/instance-type=standard-v3,node.kubernetes.io/kube-proxy-ds-ready=true,node.kubernetes.io/masq-agent-ds-ready=true,node.kubernetes.io/node-problem-detector-ds-ready=true,topology.kubernetes.io/zone=ru-central1-a,yandex.cloud/node-group-id=catlmd02qvorhugs80nm,yandex.cloud/pci-topology=k8s,yandex.cloud/preemptible=false
work-1    Ready    <none>   21h   v1.26.2   192.168.1.25   158.160.110.56   Ubuntu 20.04.6 LTS   5.4.0-174-generic   containerd://1.6.28   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=standard-v3,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/zone=ru-central1-a,kubernetes.io/arch=amd64,kubernetes.io/hostname=work-1,kubernetes.io/os=linux,node.kubernetes.io/instance-type=standard-v3,node.kubernetes.io/kube-proxy-ds-ready=true,node.kubernetes.io/masq-agent-ds-ready=true,node.kubernetes.io/node-problem-detector-ds-ready=true,topology.kubernetes.io/zone=ru-central1-a,work=true,yandex.cloud/node-group-id=cat4ehbe3g1jl4a1n2im,yandex.cloud/pci-topology=k8s,yandex.cloud/preemptible=false
 ```
 ```
 $ kubectl get nodes -o custom-columns=NAME:.metadata.name,TAINTS:.spec.taints
NAME      TAINTS
infra-1   [map[effect:NoSchedule key:node-role value:infra]]
work-1    <none>
 ```
 
![Снимок экрана_2024-04-29_11-14-35](https://github.com/Kuber-2023-12OTUS/Redrrah_repo/assets/20030296/abe79733-a1eb-4d84-ad0a-94ce1becfab4)

![Снимок экрана_2024-04-29_11-15-05](https://github.com/Kuber-2023-12OTUS/Redrrah_repo/assets/20030296/eb9178d4-8179-4ab3-8ccc-2996d958c147)


## PR checklist:
 - [x] Выставлен label с темой домашнего задания
