### PR TITLE
kubernetes-debug

### DIFF
--- a/kubernetes-debug/distroless.yaml
+++ b/kubernetes-debug/distroless.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  namespace: homework
+spec:
+  containers:
+  - name: nginx
+    image: kyos0109/nginx-distroless
+    ports:
+    - containerPort: 80


### PR DESCRIPTION
# Выполнено ДЗ №13

 - [X] Основное ДЗ
 - [X] Задание со *

## В процессе сделано:
 - Создан манифест пода с distroless образом длясозданиā контейнера kyos0109/nginx-distroless
 `kubectl apply -f distroless.yaml`
- С помощьюкоманды kubectl debug создан эфемерный контейнер
`kubectl debug -it nginx --image=dockersec/tcpdump --target nginx -- sh`
- вывод ls –la etc/nginx
```
drwxr-xr-x 3 root root 4096 Oct  5  2020 .
drwxr-xr-x 1 root root 4096 Jun  7 17:38 ..
drwxr-xr-x 2 root root 4096 Oct  5  2020 conf.d
-rw-r--r-- 1 root root 1007 Apr 21  2020 fastcgi_params
-rw-r--r-- 1 root root 2837 Apr 21  2020 koi-utf
-rw-r--r-- 1 root root 2223 Apr 21  2020 koi-win
-rw-r--r-- 1 root root 5231 Apr 21  2020 mime.types
lrwxrwxrwx 1 root root   22 Apr 21  2020 modules -> /usr/lib/nginx/modules
-rw-r--r-- 1 root root  643 Apr 21  2020 nginx.conf
```
 - вывод tcpdump -nn -i any -e port 80 
 ```
tcpdump: data link type LINUX_SLL2
tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
listening on any, link-type LINUX_SLL2 (Linux cooked v2), snapshot length 262144 bytes
09:23:18.433568 lo    In  ifindex 1 00:00:00:00:00:00 ethertype IPv4 (0x0800), length 80: 127.0.0.1.50666 > 127.0.0.1.80: Flags [S], seq 997056306, win 65495, options [mss 65495,sackOK,TS val 924063929 ecr 0,nop,wscale 7], length 0
09:23:18.433586 lo    In  ifindex 1 00:00:00:00:00:00 ethertype IPv4 (0x0800), length 80: 127.0.0.1.80 > 127.0.0.1.50666: Flags [S.], seq 3051571112, ack 997056307, win 65483, options [mss 65495,sackOK,TS val 924063929 ecr 924063929,nop,wscale 7], length 0
09:23:18.433600 lo    In  ifindex 1 00:00:00:00:00:00 ethertype IPv4 (0x0800), length 72: 127.0.0.1.50666 > 127.0.0.1.80: Flags [.], ack 1, win 512, options [nop,nop,TS val 924063929 ecr 924063929], length 0
09:23:18.433660 lo    In  ifindex 1 00:00:00:00:00:00 ethertype IPv4 (0x0800), length 807: 127.0.0.1.50666 > 127.0.0.1.80: Flags [P.], seq 1:736, ack 1, win 512, options [nop,nop,TS val 924063929 ecr 924063929], length 735: HTTP: GET / HTTP/1.1
09:23:18.433665 lo    In  ifindex 1 00:00:00:00:00:00 ethertype IPv4 (0x0800), length 72: 127.0.0.1.80 > 127.0.0.1.50666: Flags [.], ack 736, win 506, options [nop,nop,TS val 924063929 ecr 924063929], length 0
09:23:18.434005 lo    In  ifindex 1 00:00:00:00:00:00 ethertype IPv4 (0x0800), length 80: 127.0.0.1.50678 > 127.0.0.1.80: Flags [S], seq 442343784, win 65495, options [mss 65495,sackOK,TS val 924063930 ecr 0,nop,wscale 7], length 0
09:23:18.434015 lo    In  ifindex 1 00:00:00:00:00:00 ethertype IPv4 (0x0800), length 80: 127.0.0.1.80 > 127.0.0.1.50678: Flags [S.], seq 3092984991, ack 442343785, win 65483, options [mss 65495,sackOK,TS val 924063930 ecr 924063930,nop,wscale 7], length 0
09:23:18.434022 lo    In  ifindex 1 00:00:00:00:00:00 ethertype IPv4 (0x0800), length 72: 127.0.0.1.50678 > 127.0.0.1.80: Flags [.], ack 1, win 512, options [nop,nop,TS val 924063930 ecr 924063930], length 0
09:23:18.453138 lo    In  ifindex 1 00:00:00:00:00:00 ethertype IPv4 (0x0800), length 310: 127.0.0.1.80 > 127.0.0.1.50666: Flags [P.], seq 1:239, ack 736, win 512, options [nop,nop,TS val 924063949 ecr 924063929], length 238: HTTP: HTTP/1.1 200 OK
 ```
 - логи сделать kubectl port-forward pod/nginx 8080:80
 ```
root@minikube:/host# cat var/lib/docker/containers/32c2789873afc920059bcb9afe872ff39e223b236794a0a73e7f88fb465e0ed3/32c2789873afc920059bcb9afe872ff39e223b236794a0a73e7f88fb465e0ed3-json.log
{"log":"127.0.0.1 - - [29/Jun/2024:17:23:18 +0800] \"GET / HTTP/1.1\" 200 612 \"-\" \"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 YaBrowser/24.1.0.0 Safari/537.36\" \"-\"\n","stream":"stdout","time":"2024-06-29T09:23:18.462085543Z"}
{"log":"127.0.0.1 - - [29/Jun/2024:17:23:18 +0800] \"GET /favicon.ico HTTP/1.1\" 404 555 \"http://localhost:8080/\" \"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 YaBrowser/24.1.0.0 Safari/537.36\" \"-\"\n","stream":"stdout","time":"2024-06-29T09:23:18.512905363Z"}
{"log":"2024/06/29 17:23:18 [error] 7#7: *1 open() \"/usr/share/nginx/html/favicon.ico\" failed (2: No such file or directory), client: 127.0.0.1, server: localhost, request: \"GET /favicon.ico HTTP/1.1\", host: \"localhost:8080\", referrer: \"http://localhost:8080/\"\n","stream":"stderr","time":"2024-06-29T09:23:18.517568755Z"}
{"log":"127.0.0.1 - - [29/Jun/2024:18:01:36 +0800] \"GET / HTTP/1.1\" 304 0 \"-\" \"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 YaBrowser/24.1.0.0 Safari/537.36\" \"-\"\n","stream":"stdout","time":"2024-06-29T10:01:36.638019129Z"}
 ```
 - strace выполнить kubectl debug -it nginx --image=nicolaka/netshoot --target nginx -- sh
```
~ # ps aux
PID   USER     TIME  COMMAND
    1 root      0:00 nginx: master process nginx -g daemon off;
    7 bird      0:00 nginx: worker process
   40 root      0:00 sh
   46 root      0:00 ps aux
~ # strace -p 1
strace: Process 1 attached
rt_sigsuspend([], 8
```

## PR checklist:
 - [X] Выставлен label с темой домашнего задания
